### PR TITLE
Extendable 'files' declaration

### DIFF
--- a/logstash_forwarder/files/logstash-forwarder
+++ b/logstash_forwarder/files/logstash-forwarder
@@ -1,4 +1,7 @@
 {%- from 'logstash_forwarder/map.jinja' import logstash_forwarder with context %}
+{%- for id, file_group in logstash_forwarder.files_extend.items() -%}
+  {%- do logstash_forwarder.files.append(file_group) -%}
+{%- endfor -%}
 {
   "network": {
     "servers": [

--- a/logstash_forwarder/map.jinja
+++ b/logstash_forwarder/map.jinja
@@ -11,7 +11,8 @@
         'paths': ['/var/log/syslog'],
         'fields': {'type': 'syslog'}
       }
-    ]
+    ],
+    'files_extend': {}
   },
   'RedHat': {
   	'pkg': 'logstash-forwarder',
@@ -25,6 +26,7 @@
         'paths': ['/var/log/messages'],
         'fields': {'type': 'syslog'}
       }
-    ]
+    ],
+    'files_extend': {}
   }
 }, merge=salt['pillar.get']('logstash_forwarder')) %}

--- a/logstash_forwarder/map.jinja
+++ b/logstash_forwarder/map.jinja
@@ -7,7 +7,10 @@
     'log_to_syslog': True,
     'init_file': 'salt://logstash_forwarder/files/logstash-forwarder.deb.init',
     'files': [
-      {'paths': ['/var/log/syslog'], 'type': 'syslog'}
+      {
+        'paths': ['/var/log/syslog'],
+        'fields': {'type': 'syslog'}
+      }
     ]
   },
   'RedHat': {
@@ -18,7 +21,10 @@
     'log_to_syslog': True,
     'init_file': 'salt://logstash_forwarder/files/logstash-forwarder.rpm.init',
     'files': [
-      {'paths': ['/var/log/messages'], 'type': 'syslog'}
+      {
+        'paths': ['/var/log/messages'],
+        'fields': {'type': 'syslog'}
+      }
     ]
   }
 }, merge=salt['pillar.get']('logstash_forwarder')) %}

--- a/pillar.example
+++ b/pillar.example
@@ -18,6 +18,13 @@ logstash_forwarder:
                     - /var/log/nginx/*error*
                 fields:
                     type: nginx-error
+        # Extend the 'files' option. Can be specified in multiple locations/pillar files.
+        files_extend:
+            apache:
+                paths:
+                    - /var/log/apache2/*.log
+                fields:
+                    type: apache
         cert_path: /etc/ssl/certs/logstash-forwarder.crt
         log_to_syslog: true
         cert_contents: |


### PR DESCRIPTION
In its present state, the formula can't be configured in multiple places. For instance I can't create logstash_forwarder config pillars for apache and nginx and just include them like so:

```yaml
logstash_forwarder:
  files:
    apache:
      paths:
        - /var/log/apache2/*.log
      fields:
        type: apache
```
```yaml
logstash_forwarder:
  files:
    nginx:
      paths:
        - /var/log/nginx/*access*
      fields:
        type: nginx-access
```
```yaml
include:
  - logstash_forwarder.apache
  - logstash_forwarder.nginx
```
Currently this configuration would result in only nginx logs being forwarded.

This change would allow this sort of thing to be achieved through a 'files_extend' option without breaking existing configurations:
```yaml
logstash_forwarder:
  files_extend:
    apache:
      paths:
        - /var/log/apache2/*.log
      fields:
        type: apache
```