### PR TITLE
Added -quiet as default daemon option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,9 @@ this formula for two reasons:
 * The RedHat service init file is currently broken, see <https://github.com/elasticsearch/logstash-forwarder/pull/196>
 * By default, init files for both distro families enables 'log-to-syslog' when invoking 
   logstash-forwarder, which can pollute your syslog with unnecessary noise.  By default
-  this feature will remain on, but it can be turned off by setting logstash_forwarder:log_to_syslog
-  to false in your pillar data.
+  this feature will remain on, but we enable also the 'quiet' option so the configuration is ready
+  for production use. Both options can be turned off by setting logstash_forwarder:log_to_syslog or
+  logstash_forwarder:quiet to false in your pillar data.
 
 Usage
 =====
@@ -128,8 +129,10 @@ Overriding Platform Defaults
 -------------------
 This formula sets up certain defaults in map.jinja, specifically:
 
-* logstash-forwarder will send it's own messages to syslog.  You may want to turn this off once you
-  have a working configuration to keep your syslog from being too noisy.
+* logstash-forwarder will send it's own messages to syslog.
+* The 'quiet' option is enabled so the log is not polluted with too much noise.
+  You may want to turn this off when debugging. However, fatal errors are
+  always logged.
 * Name of the logstash-forwarder package is logstash-forwarder
 * Name of the logstash-forwarder service is logstash-forwarder
 * The latest version of logstash available will be installed  
@@ -140,6 +143,7 @@ These settings can be overridden by adding the appropriate keys to your
 pillar data, for example::
     logstash_forwarder:
         log_to_syslog: false
+        quiet: false
         pkg: logstash-forwarder-altversion
         svc: logstash-forwarder-alterversion
         timeout: 90

--- a/logstash_forwarder/files/logstash-forwarder.deb.init
+++ b/logstash_forwarder/files/logstash-forwarder.deb.init
@@ -13,11 +13,7 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="log shipper"
 NAME=logstash-forwarder
 DAEMON=/opt/logstash-forwarder/bin/logstash-forwarder
-{%- if logstash_forwarder.log_to_syslog == True %}
-DAEMON_ARGS="-config /etc/logstash-forwarder -spool-size 100 {% if logstash_forwarder.log_to_syslog %}-log-to-syslog{%- endif %}"
-{%- else %}
-DAEMON_ARGS="-config /etc/logstash-forwarder -spool-size 100"
-{%- endif %}
+DAEMON_ARGS="-config /etc/logstash-forwarder -spool-size 100 {% if logstash_forwarder.log_to_syslog %}-log-to-syslog{%- endif %} {% if logstash_forwarder.quiet %}-quiet{%- endif %}"
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 

--- a/logstash_forwarder/files/logstash-forwarder.rpm.init
+++ b/logstash_forwarder/files/logstash-forwarder.rpm.init
@@ -21,7 +21,7 @@ SCRIPTNAME=/etc/init.d/$NAME
 . /etc/init.d/functions
 
 [ -e /etc/sysconfig/logstash-forwarder ] && . /etc/sysconfig/logstash-forwarder
-DAEMON_ARGS="${DAEMON_ARGS:--config /etc/logstash-forwarder -spool-size 100 {% if logstash_forwarder.log_to_syslog %}-log-to-syslog{%- endif %}}"
+DAEMON_ARGS="${DAEMON_ARGS:--config /etc/logstash-forwarder -spool-size 100 {% if logstash_forwarder.log_to_syslog %}-log-to-syslog{%- endif %} {% if logstash_forwarder.quiet %}-quiet{%- endif %}}"
 
 start()
 {

--- a/logstash_forwarder/map.jinja
+++ b/logstash_forwarder/map.jinja
@@ -5,6 +5,7 @@
     'cert_path': '/etc/ssl/certs/logstash-forwarder.crt',
     'timeout': '15',
     'log_to_syslog': True,
+    'quiet': True,
     'init_file': 'salt://logstash_forwarder/files/logstash-forwarder.deb.init',
     'files': [
       {
@@ -20,6 +21,7 @@
   	'cert_path': '/etc/pki/tls/certs/logstash-forwarder.crt',
     'timeout': 15,
     'log_to_syslog': True,
+    'quiet': True,
     'init_file': 'salt://logstash_forwarder/files/logstash-forwarder.rpm.init',
     'files': [
       {

--- a/pillar.example
+++ b/pillar.example
@@ -27,6 +27,7 @@ logstash_forwarder:
                     type: apache
         cert_path: /etc/ssl/certs/logstash-forwarder.crt
         log_to_syslog: true
+        quiet: true
         cert_contents: |
             -----BEGIN CERTIFICATE-----
             MIIDBzCCAe+gAwIBAgIJAImyMODCMdTFMA0GCSqGSIb3DQEBBQUAMBoxGDAWBgNV


### PR DESCRIPTION
Added -quiet as default option to the logstash forwarder daemon. This doesn't write the verbose 'Registrar: processing 1 events' events into syslog. Fatal errors are still logged to syslog.

The -quiet option can be disabled in pillar by setting logstash_forwarder.quiet to False.