### PR TITLE
Update logstash-forwarder.deb.init

### DIFF
--- a/logstash_forwarder/files/logstash-forwarder.deb.init
+++ b/logstash_forwarder/files/logstash-forwarder.deb.init
@@ -1,4 +1,4 @@
-{%- from 'logstash_forwarder/map.jinja' import logstash_forwarder with context %}
+{%- from 'logstash_forwarder/map.jinja' import logstash_forwarder with context -%}
 #! /bin/sh
 ### BEGIN INIT INFO
 # Provides:          logstash-forwarder


### PR DESCRIPTION
This change removes a newline from the start of the init file which caused it to break when used under systemd (e.g. on Debian Jessie).