### PR TITLE
Update logstash-forwarder.rpm.init

### DIFF
--- a/logstash_forwarder/files/logstash-forwarder.rpm.init
+++ b/logstash_forwarder/files/logstash-forwarder.rpm.init
@@ -1,4 +1,4 @@
-{%- from 'logstash_forwarder/map.jinja' import logstash_forwarder with context %}
+{%- from 'logstash_forwarder/map.jinja' import logstash_forwarder with context -%}
 #!/bin/bash
 # chkconfig: 345 80 20
 # description: Logstash Forwarder


### PR DESCRIPTION
This change removes a newline from the start of the rpm init file which caused it to break when used under systemd (e.g. on CentOS 7).